### PR TITLE
Make tooltips text stay on one line

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -110,6 +110,7 @@ button.circle-button-0.disabled:active {
     border-radius: 8px;
     z-index: 99999;
     visibility: hidden;
+    white-space: nowrap;
 }
 
 [data-title] {


### PR DESCRIPTION
Before
<img width="260" alt="Screenshot 2024-01-20 at 23 34 21" src="https://github.com/akuse-app/Akuse/assets/116851769/17a60605-0cfa-498a-aee9-1b51d029b20a">


After
<img width="257" alt="Screenshot 2024-01-20 at 23 33 13" src="https://github.com/akuse-app/Akuse/assets/116851769/bf980453-3844-4e7a-8ee3-fe84a1d34f18">
